### PR TITLE
Fix missing forward slash

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,6 +1,6 @@
 FROM java:8-jdk-alpine
 
-RUN mkdir -p /app/ &&
+RUN mkdir -p /app/ && \
     mkdir -p /app/static
 
 COPY MobyStore-0.0.1-SNAPSHOT.jar /app


### PR DESCRIPTION
cc @spara 

Fixes missing forward slash in Dockerfile causing `build` error

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>