### PR TITLE
Update Postgres DB password to come from a docker secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ ehthumbs.db
 Thumbs.db
 =======
 .DS_Store
+
+# Secrets folders #
+###################
+prodsecrets

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -6,4 +6,3 @@ RUN mkdir -p /app/ && \
 COPY target/MobyArtShop-0.0.1-SNAPSHOT.jar /app
 
 CMD ["java", "-jar","/app/MobyArtShop-0.0.1-SNAPSHOT.jar", "--spring.profiles.active=postgres", "--debug"]
-

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -10,7 +10,5 @@ COPY postgresql.conf /usr/share/postgresql/9.6/
 ADD  docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
 
 # Default values for passwords and database name. Can be overridden on docker run
-
 ENV POSTGRES_USER gordonuser
-ENV POSTGRES_PASSWORD gordonpassword
 ENV POSTGRES_DB mobystore

--- a/devsecrets/postgres_password
+++ b/devsecrets/postgres_password
@@ -1,0 +1,1 @@
+gordonpassword

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.1"
 
 services:
   database:
@@ -7,12 +7,14 @@ services:
     image: mobystore_db
     environment:
       POSTGRES_USER: gordonuser
-      POSTGRES_PASSWORD: gordonpassword
+      POSTGRES_DB_PASSWORD_FILE: /run/secrets/postgres_password
       POSTGRES_DB: mobystore
     ports:
       - "5432:5432" 
     networks:
       - back-tier
+    secrets:
+      - postgres_password
     #restart: always
 
   appserver:
@@ -31,10 +33,14 @@ services:
       - back-tier
     volumes:
       - ./app/static:/static
+    secrets:
+      - postgres_password
     #restart: always
-    volumes:
-     - ./app/static:/static
 
 networks:
   front-tier:
   back-tier:
+
+secrets:
+  postgres_password:
+    file: ./devsecrets/postgres_password

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,14 +1,16 @@
-version: "3"
+version: "3.1"
 
 services:
   database:
     image: mobystore_db
     environment:
       POSTGRES_USER: gordonuser
-      POSTGRES_PASSWORD: gordonpassword
+      POSTGRES_DB_PASSWORD_FILE: /run/secrets/postgres_password
       POSTGRES_DB: mobystore
     networks:
      - back-tier
+    secrets:
+      - postgres_password
 
   appserver:
     image: mobystore_app
@@ -26,7 +28,9 @@ services:
         delay: 5s
         max_attempts: 3
         window: 120s
-  
+    secrets:
+      - postgres_password
+
   visualizer:
     image: dockersamples/visualizer:stable
     ports:
@@ -41,3 +45,7 @@ services:
 networks:
   front-tier:
   back-tier:
+
+secrets:
+  postgres_password:
+    file: ./prodsecrets/postgres_password

--- a/src/main/java/com/docker/mobyartshop/configuration/JpaConfiguration.java
+++ b/src/main/java/com/docker/mobyartshop/configuration/JpaConfiguration.java
@@ -1,6 +1,9 @@
 package com.docker.mobyartshop.configuration;
 
 import java.util.Properties;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
 
 import javax.naming.NamingException;
 import javax.persistence.EntityManagerFactory;
@@ -47,8 +50,26 @@ public class JpaConfiguration {
 	@Bean
 	@Primary
 	@ConfigurationProperties(prefix = "datasource.mobyartshop")
-	public DataSourceProperties dataSourceProperties(){
-		return new DataSourceProperties();
+	public DataSourceProperties dataSourceProperties() {
+		DataSourceProperties dataSourceProperties = new DataSourceProperties();
+
+		// From http://stackoverflow.com/questions/4716503/reading-a-plain-text-file-in-java
+		// Set password to connect to postgres using Docker secrets.
+		try(BufferedReader br = new BufferedReader(new FileReader("/run/secrets/postgres_password"))) {
+			StringBuilder sb = new StringBuilder();
+			String line = br.readLine();
+
+			while (line != null) {
+				sb.append(line);
+				sb.append(System.lineSeparator());
+				line = br.readLine();
+			}
+			dataSourceProperties.setDataPassword(sb.toString());
+		} catch (IOException e) {
+			System.err.println("Could not successfully load DB password file");
+		}
+
+		return dataSourceProperties;
 	}
 
 	/*

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,6 @@ datasource:
   mobyartshop:
     url: jdbc:postgresql://database:5432/mobystore
     username: gordonuser
-    password: gordonpassword
     driverClassName: org.postgresql.Driver
     defaultSchema:
     maxPoolSize: 20


### PR DESCRIPTION
@ManoMarks @spara 

PTAL -- implements using `docker swarm` secrets (which `docker-compose` fakes locally) for the postgres password

first step towards also using for the payment processor token for our OX demo too